### PR TITLE
Fix LibAws package URLs

### DIFF
--- a/L/LibAwsAuth/Package.toml
+++ b/L/LibAwsAuth/Package.toml
@@ -1,3 +1,3 @@
 name = "LibAwsAuth"
 uuid = "e028494f-7ddb-47cd-bd9c-7e7578dea4c5"
-repo = "git@github.com:JuliaServices/LibAwsAuth.jl.git"
+repo = "https://github.com/JuliaServices/LibAwsAuth.jl.git"

--- a/L/LibAwsCal/Package.toml
+++ b/L/LibAwsCal/Package.toml
@@ -1,3 +1,3 @@
 name = "LibAwsCal"
 uuid = "ef519ef6-af43-41a0-8ac4-eb81328190af"
-repo = "git@github.com:JuliaServices/LibAwsCal.jl.git"
+repo = "https://github.com/JuliaServices/LibAwsCal.jl.git"

--- a/L/LibAwsChecksums/Package.toml
+++ b/L/LibAwsChecksums/Package.toml
@@ -1,3 +1,3 @@
 name = "LibAwsChecksums"
 uuid = "332a3e40-df62-419b-9f04-2cb73588ccaf"
-repo = "git@github.com:JuliaServices/LibAwsChecksums.jl.git"
+repo = "https://github.com/JuliaServices/LibAwsChecksums.jl.git"

--- a/L/LibAwsCompression/Package.toml
+++ b/L/LibAwsCompression/Package.toml
@@ -1,3 +1,3 @@
 name = "LibAwsCompression"
 uuid = "51c8708f-2dd9-446d-a0d4-ba9f49ba4b23"
-repo = "git@github.com:JuliaServices/LibAwsCompression.jl.git"
+repo = "https://github.com/JuliaServices/LibAwsCompression.jl.git"

--- a/L/LibAwsEventStream/Package.toml
+++ b/L/LibAwsEventStream/Package.toml
@@ -1,3 +1,3 @@
 name = "LibAwsEventStream"
 uuid = "7707c54a-f152-44d3-a3d6-cc4209ac0b85"
-repo = "git@github.com:JuliaServices/LibAwsEventStream.jl.git"
+repo = "https://github.com/JuliaServices/LibAwsEventStream.jl.git"

--- a/L/LibAwsHTTP/Package.toml
+++ b/L/LibAwsHTTP/Package.toml
@@ -1,3 +1,3 @@
 name = "LibAwsHTTP"
 uuid = "ce851869-0d7a-41e7-95ef-2d4cb63876dd"
-repo = "git@github.com:JuliaServices/LibAwsHTTP.jl.git"
+repo = "https://github.com/JuliaServices/LibAwsHTTP.jl.git"

--- a/L/LibAwsIO/Package.toml
+++ b/L/LibAwsIO/Package.toml
@@ -1,3 +1,3 @@
 name = "LibAwsIO"
 uuid = "a5388770-19df-4151-b103-3d71de896ddf"
-repo = "git@github.com:JuliaServices/LibAwsIO.jl.git"
+repo = "https://github.com/JuliaServices/LibAwsIO.jl.git"

--- a/L/LibAwsIot/Package.toml
+++ b/L/LibAwsIot/Package.toml
@@ -1,3 +1,3 @@
 name = "LibAwsIot"
 uuid = "d022c788-31c6-4e56-9a35-f63e7e4f3ca1"
-repo = "git@github.com:JuliaServices/LibAwsIot.jl.git"
+repo = "https://github.com/JuliaServices/LibAwsIot.jl.git"

--- a/L/LibAwsMqtt/Package.toml
+++ b/L/LibAwsMqtt/Package.toml
@@ -1,3 +1,3 @@
 name = "LibAwsMqtt"
 uuid = "dbf63f58-971e-4a9b-b153-820e5f7f543b"
-repo = "git@github.com:JuliaServices/LibAwsMqtt.jl.git"
+repo = "https://github.com/JuliaServices/LibAwsMqtt.jl.git"

--- a/L/LibAwsS3/Package.toml
+++ b/L/LibAwsS3/Package.toml
@@ -1,3 +1,3 @@
 name = "LibAwsS3"
 uuid = "7e4e0a2a-738e-4919-8f64-2391d105e660"
-repo = "git@github.com:JuliaServices/LibAwsS3.jl.git"
+repo = "https://github.com/JuliaServices/LibAwsS3.jl.git"

--- a/L/LibAwsSdkutils/Package.toml
+++ b/L/LibAwsSdkutils/Package.toml
@@ -1,3 +1,3 @@
 name = "LibAwsSdkutils"
 uuid = "c5f27dc9-c37b-4573-9b6c-b90055172160"
-repo = "git@github.com:JuliaServices/LibAwsSdkutils.jl.git"
+repo = "https://github.com/JuliaServices/LibAwsSdkutils.jl.git"


### PR DESCRIPTION
In #106438 I accidentally used the SSH spec instead of HTTPS. This breaks cloning on most systems by default (like GitHub CI).

Maybe there should be a registry CI check for this, but that's another thing.
